### PR TITLE
Fix handling of server 102 in reset verification

### DIFF
--- a/aws/src/verify_reset/app.py
+++ b/aws/src/verify_reset/app.py
@@ -55,7 +55,7 @@ def lambda_handler(event, context):
         result = "unknown"
         username = ""
         password = ""
-        if server != "101" or server != "102":
+        if server not in ("101", "102"):
             server = "101"
         
         s3_client = boto3.client('s3')

--- a/aws/src/verify_reset/app.py
+++ b/aws/src/verify_reset/app.py
@@ -126,3 +126,4 @@ def lambda_handler(event, context):
         logger.info("exception")
         logger.info(str(e))
         return do_failure()
+

--- a/aws/src/verify_reset/app.py
+++ b/aws/src/verify_reset/app.py
@@ -126,4 +126,3 @@ def lambda_handler(event, context):
         logger.info("exception")
         logger.info(str(e))
         return do_failure()
-


### PR DESCRIPTION
Replace incorrect OR validation with proper membership check so valid server values (101, 102) are preserved instead of always defaulting to 101.